### PR TITLE
fix: PR自動レビューの権限チェックをwrite以上に緩和

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,8 @@ jobs:
               repo: context.repo.repo,
               username: context.payload.pull_request.user.login,
             });
-            const isAdmin = data.permission === 'admin';
+            const allowed = ['admin', 'maintain', 'write'];
+            const isAdmin = allowed.includes(data.permission);
             core.setOutput('is-admin', String(isAdmin));
 
   claude-review:


### PR DESCRIPTION
## Summary

- `admin` 権限のみ許可していたClaude自動レビューのトリガー条件を修正
- `write`・`maintain`・`admin` いずれかの権限を持つユーザーのPRでレビューが実行されるよう変更

## 変更内容

```javascript
// Before
const isAdmin = data.permission === 'admin';

// After
const allowed = ['admin', 'maintain', 'write'];
const isAdmin = allowed.includes(data.permission);
```

## Test plan

- [ ] `write` 権限のユーザーがPRを作成した際に自動レビューが実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)