### PR TITLE
feat: サウンドon/offをアイコンボタンに変更

### DIFF
--- a/src/presentation/components/TitleScreen.tsx
+++ b/src/presentation/components/TitleScreen.tsx
@@ -54,16 +54,10 @@ export function TitleScreen({ onStart, soundEnabled, onToggleSound }: TitleScree
 
         <div className="space-y-2">
           <p className="text-sm text-gray-400">サウンド</p>
-          <button
-            onClick={onToggleSound}
-            className={`w-full py-2 px-4 rounded-lg font-semibold transition-colors ${
-              soundEnabled
-                ? 'bg-blue-600 hover:bg-blue-700 text-white'
-                : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
-            }`}
-          >
-            {soundEnabled ? 'ON' : 'OFF'}
-          </button>
+          <label className="flex items-center gap-2 cursor-pointer" onClick={onToggleSound}>
+            <span className="text-xl">{soundEnabled ? '🔊' : '🔇'}</span>
+            <span>{soundEnabled ? 'ON' : 'OFF'}</span>
+          </label>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要

サウンドon/offのボタンをアイコンボタン（🔊/🔇絵文字）デザインに変更。

- ラジオボタンと同じ `flex items-center gap-2` スタイルで統一感を確保

Closes #16

Generated with [Claude Code](https://claude.ai/code)